### PR TITLE
Implement high order polynomials in 3D

### DIFF
--- a/src/fe_mesh.f90
+++ b/src/fe_mesh.f90
@@ -31,7 +31,7 @@ private
 public cartesian_mesh_2d, cartesian_mesh_3d, define_connect_tensor_2d, &
     define_connect_tensor_3d, c2fullc_2d, c2fullc_3d, fe2quad_2d, fe2quad_3d, &
     vtk_save, get_element_3d, fe_eval_xyz, line_save, fe2quad_3d_lobatto, &
-    quad2fe_3d
+    quad2fe_3d, quad2fe_3d_lobatto
 
 contains
 
@@ -422,6 +422,28 @@ real(dp) :: rhs(Nb), sol(Nb)
 call assemble_3d_coo_rhs(Ne, p, uq, jac_det, wtq3, ib, phi_v, rhs)
 sol = solve_cg(Sp, Sj, Sx, rhs, zeros(size(rhs)), 1e-12_dp, 400)
 call c2fullc_3d(in, ib, sol, fullu)
+end subroutine
+
+subroutine quad2fe_3d_lobatto(Ne, p, in, uq, fullu)
+! Transforms quadrature-grid representation to FE-coefficient (fullu).
+! fullu is a full FE coefficient vector, having values for all nodes in the
+! mesh, including domain-boundary nodes.
+! Assumes the same 'jac_det' for each finite element and spectral elements.
+integer, intent(in) :: Ne, p
+real(dp), intent(in) :: uq(:, :, :, :)
+integer, intent(in) :: in(:, :, :, :)
+real(dp), intent(out) :: fullu(:)
+integer :: ie, iqx, iqy, iqz
+! The quad points are the coefficients for spectral elements
+do ie = 1, Ne
+    do iqz = 1, p+1
+    do iqy = 1, p+1
+    do iqx = 1, p+1
+        fullu(in(iqx, iqy, iqz, ie)) = uq(iqx, iqy, iqz, ie)
+    end do
+    end do
+    end do
+end do
 end subroutine
 
 subroutine fe2quad_3d_lobatto(elems, xiq, in, fullu, uq)

--- a/src/ofdft_fe.f90
+++ b/src/ofdft_fe.f90
@@ -444,7 +444,7 @@ end if
 if (WITH_UMFPACK) then
     call solve(Ap, Aj, Ax, sol, rhs, matd)
 else
-    sol = solve_cg(Ap, Aj, Ax, rhs, zeros(size(rhs)), 1e-12_dp, 800)
+    sol = solve_cg(Ap, Aj, Ax, rhs, zeros(size(rhs)), 1e-12_dp, 4000)
 end if
 if (verbose_) then
     print *, "Converting..."
@@ -588,7 +588,7 @@ print *, "Solving..."
 if (WITH_UMFPACK) then
     call solve(fed%Ap, fed%Aj, fed%Ax, sol, rhs, fed%matd)
 else
-    sol = solve_cg(fed%Ap, fed%Aj, fed%Ax, rhs, zeros(size(rhs)), 1e-12_dp, 800)
+    sol = solve_cg(fed%Ap, fed%Aj, fed%Ax, rhs, zeros(size(rhs)), 1e-12_dp, 4000)
 end if
 print *, "Converting..."
 call c2fullc_3d(fed%in, fed%ib, sol, fullsol)

--- a/src/ofdft_fe.f90
+++ b/src/ofdft_fe.f90
@@ -7,7 +7,7 @@ use fe_mesh, only: cartesian_mesh_3d, define_connect_tensor_3d, &
     fe2quad_3d_lobatto, quad2fe_3d
 use poisson3d_assembly, only: assemble_3d, integral, func2quad, func_xyz, &
     assemble_3d_precalc, assemble_3d_csr, assemble_3d_coo_A, &
-    assemble_3d_coo_rhs, local_overlap_matrix
+    assemble_3d_coo_rhs, local_overlap_matrix, assemble_3d_coo_rhs_spectral
 use feutils, only: get_parent_nodes, get_parent_quad_pts_wts, quad_gauss, &
     quad_lobatto
 !use linalg, only: solve
@@ -242,8 +242,13 @@ print *, "Total (negative) ionic charge: ", background * (fed%Lx*fed%Ly*fed%Lz)
 print *, "Subtracting constant background (Q/V): ", background
 nenq_neutral = nenq_pos - background
 print *, "Assembling RHS..."
-call assemble_3d_coo_rhs(fed%Ne, fed%p, 4*pi*nenq_neutral, fed%jac_det, fed%wtq3, &
-    fed%ib, fed%phi_v, rhs)
+if (fed%spectral) then
+    call assemble_3d_coo_rhs_spectral(fed%Ne, fed%p, 4*pi*nenq_neutral, &
+    fed%jac_det, fed%wtq3, fed%ib, rhs)
+else
+    call assemble_3d_coo_rhs(fed%Ne, fed%p, 4*pi*nenq_neutral, fed%jac_det, &
+        fed%wtq3, fed%ib, fed%phi_v, rhs)
+end if
 print *, "sum(rhs):    ", sum(rhs)
 print *, "integral rhs:", integral(fed%nodes, fed%elems, fed%wtq3, nenq_neutral)
 print *, "Solving..."
@@ -410,7 +415,13 @@ nq_neutral = nq_pos - background
 if (verbose_) then
     print *, "Assembling RHS..."
 end if
-call assemble_3d_coo_rhs(Ne, p, 4*pi*nq_neutral, jac_det, wtq3, ib, phi_v, rhs)
+if (spectral) then
+    call assemble_3d_coo_rhs_spectral(Ne, p, 4*pi*nq_neutral, jac_det, wtq3, &
+        ib, rhs)
+else
+    call assemble_3d_coo_rhs(Ne, p, 4*pi*nq_neutral, jac_det, wtq3, &
+        ib, phi_v, rhs)
+end if
 if (verbose_) then
     print *, "sum(rhs):    ", sum(rhs)
     print *, "integral rhs:", integral(nodes, elems, wtq3, nq_neutral)
@@ -550,8 +561,13 @@ print *, "Total (negative) ionic charge: ", background * (fed%Lx*fed%Ly*fed%Lz)
 print *, "Subtracting constant background (Q/V): ", background
 nenq_neutral = nenq_pos - background
 print *, "Assembling RHS..."
-call assemble_3d_coo_rhs(fed%Ne, fed%p, 4*pi*nenq_neutral, fed%jac_det, fed%wtq3, &
-    fed%ib, fed%phi_v, rhs)
+if (fed%spectral) then
+    call assemble_3d_coo_rhs_spectral(fed%Ne, fed%p, 4*pi*nenq_neutral, &
+        fed%jac_det, fed%wtq3, fed%ib, rhs)
+else
+    call assemble_3d_coo_rhs(fed%Ne, fed%p, 4*pi*nenq_neutral, &
+        fed%jac_det, fed%wtq3, fed%ib, fed%phi_v, rhs)
+end if
 print *, "sum(rhs):    ", sum(rhs)
 print *, "integral rhs:", integral(fed%nodes, fed%elems, fed%wtq3, nenq_neutral)
 print *, "Solving..."

--- a/src/ofdft_fe.f90
+++ b/src/ofdft_fe.f90
@@ -161,8 +161,10 @@ call assemble_3d_coo_A(fed%Ne, fed%p, fed%ib, Am_loc, matAi_coo, matAj_coo, matA
 print *, "COO -> CSR"
 call coo2csr_canonical(matAi_coo(:idx), matAj_coo(:idx), matAx_coo(:idx), &
     fed%Ap, fed%Aj, fed%Ax)
-print *, "DOFs =", fed%Nb
-print *, "nnz =", size(fed%Ax)
+print *, "CSR Matrix:"
+print *, "    dimension:", fed%Nb
+print *, "    number of nonzeros:", size(fed%Ax)
+print "('     density:',f11.8,'%')", size(fed%Ax)*100._dp / real(fed%Nb, dp)**2
 if (WITH_UMFPACK) then
     print *, "umfpack factorize"
     call factorize(fed%Nb, fed%Ap, fed%Aj, fed%Ax, fed%matd)
@@ -176,7 +178,10 @@ call assemble_3d_coo_A(fed%Ne, fed%p, fed%ib, Am_loc, matAi_coo, matAj_coo, matA
 print *, "COO -> CSR"
 call coo2csr_canonical(matAi_coo(:idx), matAj_coo(:idx), matAx_coo(:idx), &
     fed%Sp, fed%Sj, fed%Sx)
-print *, "nnz =", size(fed%Sx)
+print *, "CSR Matrix:"
+print *, "    dimension:", fed%Nb
+print *, "    number of nonzeros:", size(fed%Sx)
+print "('     density:',f11.8,'%')", size(fed%Sx)*100._dp / real(fed%Nb, dp)**2
 end subroutine
 
 subroutine free_fe_umfpack(fed)

--- a/src/ofdft_fe.f90
+++ b/src/ofdft_fe.f90
@@ -42,7 +42,7 @@ type fe_data
     real(dp), allocatable :: nodes(:, :)
     ! elems(:, i) are nodes of the i-th element
     integer, allocatable :: elems(:, :)
-    real(dp), allocatable :: xin(:), xiq(:), wtq3(:, :, :)
+    real(dp), allocatable :: xin(:), xiq(:), wtq(:), wtq3(:, :, :)
     real(dp), allocatable :: dphihq(:, :)
     integer, allocatable :: in(:, :, :, :), ib(:, :, :, :)
     ! The CSR matrix A (Ap, Aj, Ax) is the dicrete Poisson system matrix
@@ -117,7 +117,7 @@ integer :: Nn, ibc
 integer :: i, j, k
 integer :: Ncoo
 integer, allocatable :: matAi_coo(:), matAj_coo(:)
-real(dp), allocatable :: matAx_coo(:), wtq(:), Am_loc(:, :, :, :, :, :)
+real(dp), allocatable :: matAx_coo(:), Am_loc(:, :, :, :, :, :)
 integer :: idx
 logical :: spectral_speedup_
 spectral_speedup_ = .true.
@@ -153,9 +153,10 @@ end if
 
 allocate(fed%xin(p+1))
 call get_parent_nodes(2, p, fed%xin)
-allocate(fed%xiq(Nq), wtq(Nq), fed%wtq3(Nq, Nq, Nq))
-call get_parent_quad_pts_wts(quad_type, Nq, fed%xiq, wtq)
-forall(i=1:Nq, j=1:Nq, k=1:Nq) fed%wtq3(i, j, k) = wtq(i)*wtq(j)*wtq(k)
+allocate(fed%xiq(Nq), fed%wtq(Nq), fed%wtq3(Nq, Nq, Nq))
+call get_parent_quad_pts_wts(quad_type, Nq, fed%xiq, fed%wtq)
+forall(i=1:Nq, j=1:Nq, k=1:Nq) &
+        fed%wtq3(i, j, k) = fed%wtq(i)*fed%wtq(j)*fed%wtq(k)
 allocate(fed%phihq(size(fed%xiq), size(fed%xin)))
 allocate(fed%dphihq(size(fed%xiq), size(fed%xin)))
 ! Tabulate parent basis at quadrature points
@@ -191,7 +192,7 @@ if (fed%spectral) then
         fed%nodes(1, fed%elems(7, 1)) - fed%nodes(1, fed%elems(1, 1)), &
         fed%nodes(2, fed%elems(7, 1)) - fed%nodes(2, fed%elems(1, 1)), &
         fed%nodes(3, fed%elems(7, 1)) - fed%nodes(3, fed%elems(1, 1)), &
-        wtq, matAi_coo, matAj_coo, matAx_coo, idx, fed%jac_det)
+        fed%wtq, matAi_coo, matAj_coo, matAx_coo, idx, fed%jac_det)
 else
     call assemble_3d_coo_A(fed%Ne, fed%p, fed%ib, Am_loc, matAi_coo, matAj_coo, matAx_coo, idx)
 end if

--- a/src/ofdft_fe.f90
+++ b/src/ofdft_fe.f90
@@ -30,6 +30,8 @@ public free_energy_min, radial_density_fourier, fe_data, initialize_fe, &
 logical, parameter :: WITH_UMFPACK=.false.
 
 type fe_data
+    ! -------------------------------------------------------
+    ! Variables in this section are always defined.
     real(dp) :: Lx, Ly, Lz, jac_det
     integer :: p, Nb, Nq, Ne
     integer :: Nx, Ny, Nz ! Number of elements in each direction
@@ -40,17 +42,26 @@ type fe_data
     real(dp), allocatable :: nodes(:, :)
     ! elems(:, i) are nodes of the i-th element
     integer, allocatable :: elems(:, :)
-    real(dp), allocatable :: xin(:), xiq(:), wtq3(:, :, :), phihq(:, :)
-    real(dp), allocatable :: phi_v(:, :, :, :, :, :), dphihq(:, :)
+    real(dp), allocatable :: xin(:), xiq(:), wtq3(:, :, :)
+    real(dp), allocatable :: dphihq(:, :)
     integer, allocatable :: in(:, :, :, :), ib(:, :, :, :)
-    ! The CSR matrix S (Sp, Sj, Sx) is the overlap matrix
-    integer, allocatable :: Sp(:), Sj(:)
-    real(dp), allocatable :: Sx(:)
     ! The CSR matrix A (Ap, Aj, Ax) is the dicrete Poisson system matrix
     integer, allocatable :: Ap(:), Aj(:)
     real(dp), allocatable :: Ax(:)
-    ! If WITH_UMFPACK==.true., then 'matd' contains the factorized matrix A
-    ! (Ap, Aj, Ax). Otherwise it is unused.
+
+    ! -------------------------------------------------------
+    ! Variables in this section are only used if spectral==.false., otherwise
+    ! they are undefined.
+    real(dp), allocatable :: phihq(:, :)
+    real(dp), allocatable :: phi_v(:, :, :, :, :, :)
+    ! The CSR matrix S (Sp, Sj, Sx) is the overlap matrix
+    integer, allocatable :: Sp(:), Sj(:)
+    real(dp), allocatable :: Sx(:)
+
+    ! -------------------------------------------------------
+    ! Variables in this section are only used if WITH_UMFPACK==.true., otherwise
+    ! they are undefined.
+    ! 'matd' contains the factorized matrix A (Ap, Aj, Ax)
     type(umfpack_numeric) :: matd
 end type
 

--- a/src/ofdft_fe.f90
+++ b/src/ofdft_fe.f90
@@ -4,7 +4,7 @@ use types, only: dp
 use feutils, only: phih, dphih
 use fe_mesh, only: cartesian_mesh_3d, define_connect_tensor_3d, &
     c2fullc_3d, fe2quad_3d, vtk_save, fe_eval_xyz, line_save, &
-    fe2quad_3d_lobatto, quad2fe_3d
+    fe2quad_3d_lobatto
 use poisson3d_assembly, only: assemble_3d, integral, func2quad, func_xyz, &
     assemble_3d_precalc, assemble_3d_csr, assemble_3d_coo_A, &
     assemble_3d_coo_rhs, local_overlap_matrix, &

--- a/src/poisson3d_assembly.f90
+++ b/src/poisson3d_assembly.f90
@@ -8,7 +8,7 @@ implicit none
 private
 public assemble_3d, integral, func2quad, func_xyz, assemble_3d_precalc, &
     assemble_3d_coo, assemble_3d_csr, assemble_3d_coo_rhs, assemble_3d_coo_A, &
-    local_overlap_matrix
+    local_overlap_matrix, assemble_3d_coo_rhs_spectral
 
 interface
     real(dp) function func_xyz(x, y, z)
@@ -323,6 +323,32 @@ do e = 1, Ne
         ! to check that:
         ! call assert(j /= 0)
         rhs(j) = rhs(j) + sum(phi_v(:, :, :, bx, by, bz) * fq)
+    end do
+    end do
+    end do
+end do
+end subroutine
+
+subroutine assemble_3d_coo_rhs_spectral(Ne, p, rhsq, jac_det, wtq, ib, rhs)
+real(dp), intent(in):: wtq(:, :, :), rhsq(:, :, :, :)
+integer, intent(in):: ib(:, :, :, :)
+integer, intent(in) :: Ne, p
+real(dp), intent(in) :: jac_det
+real(dp), intent(out):: rhs(:)
+real(dp), dimension(size(wtq, 1), size(wtq, 2), size(wtq, 3)) :: fq
+integer :: e, j
+integer :: bx, by, bz
+rhs = 0
+do e = 1, Ne
+    fq = rhsq(:, :, :, e) * jac_det * wtq
+    do bz = 1, p+1
+    do by = 1, p+1
+    do bx = 1, p+1
+        j = ib(bx, by, bz, e)
+        ! For periodic BC, 'j' is always nonzero. Uncomment the following line
+        ! to check that:
+        ! call assert(j /= 0)
+        rhs(j) = rhs(j) + fq(bx, by, bz)
     end do
     end do
     end do

--- a/src/poisson3d_assembly.f90
+++ b/src/poisson3d_assembly.f90
@@ -8,7 +8,8 @@ implicit none
 private
 public assemble_3d, integral, func2quad, func_xyz, assemble_3d_precalc, &
     assemble_3d_coo, assemble_3d_csr, assemble_3d_coo_rhs, assemble_3d_coo_A, &
-    local_overlap_matrix, assemble_3d_coo_rhs_spectral
+    local_overlap_matrix, assemble_3d_coo_rhs_spectral, &
+    assemble_3d_coo_A_spectral
 
 interface
     real(dp) function func_xyz(x, y, z)
@@ -248,6 +249,110 @@ do e = 1, Ne
     end do
 end do
 !call assert(idx == Ne*(p+1)**6)
+end subroutine
+
+subroutine assemble_3d_coo_A_spectral(Ne, p, ib, dphihq, lx, ly, lz, wtq, matAi, matAj, matAx, idx, jac_det)
+! Assembles the matrix A, assuming spectral elements (Guass-Lobatto integration
+! points and Nq=p+1).
+! Assumes ib is never 0!
+integer, intent(in):: ib(:, :, :, :)
+integer, intent(in) :: Ne, p
+real(dp), intent(in) :: lx, ly, lz
+real(dp), intent(in):: wtq(:), dphihq(:, :)
+integer, intent(out) :: matAi(:), matAj(:)
+real(dp), intent(out) :: matAx(:)
+integer, intent(out) :: idx
+real(dp), intent(out) :: jac_det
+integer :: e, i, j
+integer :: ax, ay, az, bx, by, bz
+real(dp) :: jacx, jacy, jacz
+real(dp) :: t1, t2
+real(dp) :: a_loc(p+1, p+1)
+call assert(all(ib > 0))
+
+call cpu_time(t1)
+
+jacx = lx/2
+jacy = ly/2
+jacz = lz/2
+jac_det = abs(jacx*jacy*jacz)
+
+do bx = 1, p+1
+do ax = 1, p+1
+    a_loc(ax, bx) = sum(dphihq(:, ax) * dphihq(:, bx) * wtq) * jac_det
+end do
+end do
+
+! Make sure there are no zeros in the local matrix
+call assert(all(abs(a_loc) > 1e-12_dp))
+
+idx = 0
+do e = 1, Ne
+    do az = 1, p+1
+    do ay = 1, p+1
+    do ax = 1, p+1
+        i = ib(ax, ay, az, e)
+
+        by = ay
+        bz = az
+        do bx = 1, p+1
+            j = ib(bx, by, bz, e)
+            if (j > i) cycle
+            idx = idx + 1
+            matAi(idx) = i
+            matAj(idx) = j
+            matAx(idx) = a_loc(ax, bx) / jacx**2 * wtq(ay)*wtq(az)
+            if (i /= j) then
+                ! Symmetric contribution
+                idx = idx + 1
+                matAi(idx) = j
+                matAj(idx) = i
+                matAx(idx) = matAx(idx-1)
+            end if
+        end do
+
+        bx = ax
+        bz = az
+        do by = 1, p+1
+            j = ib(bx, by, bz, e)
+            if (j > i) cycle
+            idx = idx + 1
+            matAi(idx) = i
+            matAj(idx) = j
+            matAx(idx) = a_loc(ay, by) / jacy**2 * wtq(ax)*wtq(az)
+            if (i /= j) then
+                ! Symmetric contribution
+                idx = idx + 1
+                matAi(idx) = j
+                matAj(idx) = i
+                matAx(idx) = matAx(idx-1)
+            end if
+        end do
+
+        bx = ax
+        by = ay
+        do bz = 1, p+1
+            j = ib(bx, by, bz, e)
+            if (j > i) cycle
+            idx = idx + 1
+            matAi(idx) = i
+            matAj(idx) = j
+            matAx(idx) = a_loc(az, bz) / jacz**2 * wtq(ax)*wtq(ay)
+            if (i /= j) then
+                ! Symmetric contribution
+                idx = idx + 1
+                matAi(idx) = j
+                matAj(idx) = i
+                matAx(idx) = matAx(idx-1)
+            end if
+        end do
+
+    end do
+    end do
+    end do
+end do
+call cpu_time(t2)
+print *, "Assembly time:", t2-t1, "s"
 end subroutine
 
 subroutine assemble_3d_coo(Ne, p, rhsq, jac_det, wtq, ib, Am_loc, phi_v, &

--- a/src/poisson3d_assembly.f90
+++ b/src/poisson3d_assembly.f90
@@ -115,6 +115,7 @@ real(dp) :: jacx, jacy, jacz
 real(dp), intent(out) :: jac_det
 real(dp), intent(out), dimension(:, :, :, :, :, :) :: Am_loc, phi_v
 ! Precalculate basis functions:
+print *, "Precalculate basis functions"
 !$omp parallel default(none) shared(p, Nq, phihq, dphihq, phi_v, phi_dx, phi_dy, phi_dz) private(ax, ay, az, iqx, iqy, iqz)
 !$omp do
 do az = 1, p+1
@@ -147,6 +148,7 @@ phi_dx = phi_dx / jacx
 phi_dy = phi_dy / jacy
 phi_dz = phi_dz / jacz
 ! Precalculate element matrix:
+print *, "Precalculate element matrix"
 !$omp parallel default(none) shared(p, phi_dx, phi_dy, phi_dz, jac_det, wtq, Am_loc) private(ax, ay, az, bx, by, bz)
 !$omp do
 do bz = 1, p+1

--- a/src/tests/fem/test_free_energy4.f90
+++ b/src/tests/fem/test_free_energy4.f90
@@ -18,7 +18,7 @@ use feutils, only: quad_lobatto
 use md, only: positions_fcc
 use converged_energies, only: four_gaussians
 use poisson3d_assembly, only: func2quad
-use fe_mesh, only: quad2fe_3d, fe_eval_xyz
+use fe_mesh, only: quad2fe_3d, quad2fe_3d_lobatto, fe_eval_xyz
 implicit none
 real(dp) :: Eee, Een, Ts, Exc, Etot, Etot_conv
 integer :: p, DOF, Nq
@@ -87,9 +87,13 @@ call initialize_fe(L, Nex, Ney, Nez, p, Nq, quad_lobatto, fed)
 allocate(nq_pos(fed%Nq, fed%Nq, fed%Nq, fed%Ne))
 allocate(fullsol(maxval(fed%in)))
 nq_pos = func2quad(fed%nodes, fed%elems, fed%xiq, fne)
-call quad2fe_3d(fed%Ne, fed%Nb, fed%p, fed%jac_det, fed%wtq3, &
-        fed%Sp, fed%Sj, fed%Sx, fed%phi_v, fed%in, fed%ib, &
-        nq_pos, fullsol)
+if (fed%spectral) then
+    call quad2fe_3d_lobatto(fed%Ne, fed%p, fed%in, nq_pos, fullsol)
+else
+    call quad2fe_3d(fed%Ne, fed%Nb, fed%p, fed%jac_det, fed%wtq3, &
+            fed%Sp, fed%Sj, fed%Sx, fed%phi_v, fed%in, fed%ib, &
+            nq_pos, fullsol)
+end if
 do i = 1, Ng
 do j = 1, Ng
 do k = 1, Ng

--- a/src/tests/fem/test_functional_derivative.f90
+++ b/src/tests/fem/test_functional_derivative.f90
@@ -16,7 +16,8 @@ use interp3d, only: trilinear
 use feutils, only: quad_lobatto
 use md, only: positions_fcc
 use converged_energies, only: one_gaussian, four_gaussians
-use poisson3d_assembly, only: func2quad, integral, assemble_3d_coo_rhs
+use poisson3d_assembly, only: func2quad, integral, assemble_3d_coo_rhs, &
+    assemble_3d_coo_rhs_spectral
 use fe_mesh, only: c2fullc_3d, fe2quad_3d, fe2quad_3d_lobatto
 implicit none
 real(dp) :: Eee, Een, Ts, Exc, Etot, Etot_conv
@@ -89,8 +90,13 @@ print *, "Total (negative) ionic charge: ", background * (fed%Lx*fed%Ly*fed%Lz)
 print *, "Subtracting constant background (Q/V): ", background
 nenq_neutral = nenq_pos - background
 print *, "Assembling RHS..."
-call assemble_3d_coo_rhs(fed%Ne, fed%p, 4*pi*nenq_neutral, fed%jac_det, fed%wtq3, &
-    fed%ib, fed%phi_v, rhs)
+if (fed%spectral) then
+    call assemble_3d_coo_rhs_spectral(fed%Ne, fed%p, 4*pi*nenq_neutral, &
+        fed%jac_det, fed%wtq3, fed%ib, rhs)
+else
+    call assemble_3d_coo_rhs(fed%Ne, fed%p, 4*pi*nenq_neutral, &
+        fed%jac_det, fed%wtq3, fed%ib, fed%phi_v, rhs)
+end if
 print *, "sum(rhs):    ", sum(rhs)
 print *, "integral rhs:", integral(fed%nodes, fed%elems, fed%wtq3, nenq_neutral)
 print *, "Solving..."

--- a/src/tests/test_ofmd_fft.f90
+++ b/src/tests/test_ofmd_fft.f90
@@ -15,7 +15,7 @@ use ofdft_fe, only: radial_density_fourier, initialize_fe, &
     free_energy_min_low_level, fe_data
 use interp3d, only: trilinear
 use poisson3d_assembly, only: func2quad
-use fe_mesh, only: quad2fe_3d, fe_eval_xyz, vtk_save
+use fe_mesh, only: quad2fe_3d, quad2fe_3d_lobatto, fe_eval_xyz, vtk_save
 implicit none
 
 ! All variables are in Hartree atomic units
@@ -234,9 +234,13 @@ contains
 
     ! Calculate forces using FE density
     print *, "FULLSOL"
-    call quad2fe_3d(fed%Ne, fed%Nb, fed%p, fed%jac_det, fed%wtq3, &
-            fed%Sp, fed%Sj, fed%Sx, fed%phi_v, fed%in, fed%ib, &
-            nq_pos, fullsol)
+    if (fed%spectral) then
+        call quad2fe_3d_lobatto(fed%Ne, fed%p, fed%in, nq_pos, fullsol)
+    else
+        call quad2fe_3d(fed%Ne, fed%Nb, fed%p, fed%jac_det, fed%wtq3, &
+                fed%Sp, fed%Sj, fed%Sx, fed%phi_v, fed%in, fed%ib, &
+                nq_pos, fullsol)
+    end if
     print *, "ne (FFT) ="
     print *, ne(:3, :3, :3)
     print *, "neG (FFT) ="


### PR DESCRIPTION
The assembly was sped up considerably for spectral elements, so that one can use any order in 3D (up to p=63, Nq=p+1=64, until we implement higher order quadrature rules).